### PR TITLE
model-manifest: Go 'ask' client, executor keep-alive, Gemma 4 binding support

### DIFF
--- a/experiments/model-manifest/.gitignore
+++ b/experiments/model-manifest/.gitignore
@@ -3,3 +3,4 @@ cas/
 *.pt2.binding.json
 *.manifest.json
 cached.binding.json
+/ask

--- a/experiments/model-manifest/cmd/ask/main.go
+++ b/experiments/model-manifest/cmd/ask/main.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ask: inference against an exported model artifact with zero PyTorch
+// on the client. Ships manifest + binding + weightless graphs to a
+// ModelExecutor over gRPC (auto port-forwarding to the pod), opens a
+// session, and asks a question. The executor rehydrates weights from
+// content-addressed storage on its side; this binary never touches
+// them.
+package main
+
+import (
+	"bufio"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	pb "github.com/gke-labs/generation-ai/experiments/model-manifest/pkg/api/v1alpha1"
+)
+
+const maxMsgSize = 128 * 1024 * 1024
+
+func main() {
+	pod := flag.String("pod", "manifest-executor-grpc", "executor pod to port-forward to")
+	addr := flag.String("addr", "", "executor address (skips port-forward)")
+	manifest := flag.String("manifest", "HuggingFaceTB--SmolLM2-135M-Instruct.manifest.json", "manifest json")
+	binding := flag.String("binding", "cached.binding.json", "binding json")
+	prefill := flag.String("prefill", "prefill.pt2", "prefill graph")
+	decode := flag.String("decode", "decode.pt2", "decode graph")
+	prompt := flag.String("prompt", "Is the sky blue?", "prompt")
+	maxNewTokens := flag.Int("max-new-tokens", 96, "max new tokens")
+	flag.Parse()
+
+	if *addr == "" {
+		forwarded, stop, err := portForward(*pod)
+		if err != nil {
+			log.Fatalf("port-forward: %v", err)
+		}
+		defer stop()
+		*addr = forwarded
+	}
+
+	conn, err := grpc.NewClient(*addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallSendMsgSize(maxMsgSize),
+			grpc.MaxCallRecvMsgSize(maxMsgSize),
+		))
+	if err != nil {
+		log.Fatalf("dial %s: %v", *addr, err)
+	}
+	defer conn.Close()
+	client := pb.NewModelExecutorClient(conn)
+
+	manifestJSON := mustRead(*manifest)
+	bindingJSON := mustRead(*binding)
+	prefillGraph := mustRead(*prefill)
+	decodeGraph := mustRead(*decode)
+	fmt.Printf("shipping artifact: %d KB manifest, %d KB binding, %d MB graphs\n",
+		len(manifestJSON)/1024, len(bindingJSON)/1024,
+		(len(prefillGraph)+len(decodeGraph))/(1024*1024))
+
+	// LoadModel triggers weight rehydration executor-side (range
+	// requests into its CAS): give it time on a cold cache.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	if _, err := client.LoadModel(ctx, &pb.LoadModelRequest{
+		ManifestJson: string(manifestJSON),
+		BindingJson:  string(bindingJSON),
+		PrefillGraph: prefillGraph,
+		DecodeGraph:  decodeGraph,
+	}); err != nil {
+		log.Fatalf("LoadModel: %v", err)
+	}
+	fmt.Printf("model loaded in %.1fs\n", time.Since(start).Seconds())
+
+	session, err := client.NewSession(ctx, &pb.NewSessionRequest{})
+	if err != nil {
+		log.Fatalf("NewSession: %v", err)
+	}
+
+	ask := func(text string) {
+		start := time.Now()
+		reply, err := client.Chat(ctx, &pb.ChatRequest{
+			SessionId:    session.SessionId,
+			Text:         text,
+			MaxNewTokens: int32(*maxNewTokens),
+		})
+		if err != nil {
+			log.Fatalf("Chat: %v", err)
+		}
+		fmt.Printf("\n>>> %s\n%s\n\n", text, reply.Text)
+		fmt.Printf("(%d tokens, %.1f ms/token on the executor, %.1fs round trip)\n",
+			reply.Generated, reply.MsPerToken, time.Since(start).Seconds())
+	}
+	ask(*prompt)
+	// Same session: exercises the KV cache (incremental prefill) and
+	// shows steady-state speed once the decode graph is compiled.
+	ask("Summarize your answer in one short sentence.")
+}
+
+func mustRead(path string) []byte {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}
+
+// portForward starts `kubectl port-forward` on an ephemeral local port
+// and returns the local address once the tunnel is ready.
+func portForward(pod string) (string, func(), error) {
+	cmd := exec.Command("kubectl", "port-forward", "pod/"+pod, ":50051")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", nil, err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return "", nil, err
+	}
+	stop := func() { _ = cmd.Process.Kill() }
+
+	re := regexp.MustCompile(`Forwarding from 127\.0\.0\.1:(\d+)`)
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		if m := re.FindStringSubmatch(scanner.Text()); m != nil {
+			addr := "127.0.0.1:" + m[1]
+			fmt.Printf("port-forward ready: %s -> %s:50051\n", addr, pod)
+			return addr, stop, nil
+		}
+	}
+	stop()
+	return "", nil, fmt.Errorf("port-forward to %s never became ready", pod)
+}

--- a/experiments/model-manifest/dev/tasks/run-in-kube
+++ b/experiments/model-manifest/dev/tasks/run-in-kube
@@ -62,7 +62,8 @@ def run_pod(pod, yaml_path, image, device, atol):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--target", choices=["cpu", "gpu", "both"], default="both")
+    parser.add_argument("--target", choices=["cpu", "gpu", "g4", "both"],
+                        default="both")
     parser.add_argument("--image", help="skip build, use this image")
     parser.add_argument("--keep", action="store_true",
                         help="leave pods running afterwards")
@@ -76,7 +77,10 @@ def main():
 
     image = args.image
     if not image:
-        project = run("gcloud config get-value project", capture=True)
+        # GCP_PROJECT_ID overrides the gcloud default, which may point at
+        # an unrelated project.
+        project = os.environ.get("GCP_PROJECT_ID") or run(
+            "gcloud config get-value project", capture=True)
         image = (f"gcr.io/{project}/generation-ai/"
                  f"manifest-executor:{int(time.time())}")
         run(f"gcloud builds submit --config {os.path.join(BASE, 'cloudbuild.yaml')} "
@@ -90,9 +94,14 @@ def main():
         # of scale ~30); argmax equality is the meaningful check here.
         run_pod("manifest-executor-gpu", "k8s/executor-pod-gpu.yaml",
                 image, "cuda", 1.0)
+    if args.target == "g4":
+        # RTX PRO 6000 pool; autoscales from zero, allow provisioning time.
+        run_pod("manifest-executor-g4", "k8s/executor-pod-g4.yaml",
+                image, "cuda", 1.0)
 
     if not args.keep:
-        for pod in ("manifest-executor-cpu", "manifest-executor-gpu"):
+        for pod in ("manifest-executor-cpu", "manifest-executor-gpu",
+                    "manifest-executor-g4"):
             subprocess.call(
                 f"kubectl delete pod {pod} --ignore-not-found --wait=false",
                 shell=True)

--- a/experiments/model-manifest/go.mod
+++ b/experiments/model-manifest/go.mod
@@ -2,6 +2,8 @@ module github.com/gke-labs/generation-ai/experiments/model-manifest
 
 go 1.26.2
 
+toolchain go1.26.6
+
 require (
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11

--- a/experiments/model-manifest/images/manifest-executor/Dockerfile
+++ b/experiments/model-manifest/images/manifest-executor/Dockerfile
@@ -28,7 +28,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # image runs on both CPU and GPU nodes.
 RUN pip install --no-cache-dir \
     torch==2.13.0 \
-    transformers==5.14.0 \
+    transformers==5.14.1 \
+    grpcio \
+    protobuf \
     requests
 
 COPY src/ /app/src/

--- a/experiments/model-manifest/k8s/executor-grpc-gpu.yaml
+++ b/experiments/model-manifest/k8s/executor-grpc-gpu.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Long-lived gRPC executor on an L4: clients ship the interchange
+# artifact over LoadModel (no kubectl cp) and chat over sessions.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: manifest-executor-grpc
+  labels:
+    app: manifest-executor
+    variant: grpc-gpu
+spec:
+  nodeSelector:
+    cloud.google.com/gke-accelerator: nvidia-l4
+  containers:
+    - name: executor
+      image: IMAGE_PLACEHOLDER
+      command: ["python", "src/serve_grpc.py"]
+      workingDir: /app
+      ports:
+        - containerPort: 50051
+      env:
+        - name: PYTHONPATH
+          value: /app/src
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64
+      resources:
+        requests:
+          cpu: "4"
+          memory: 16Gi
+        limits:
+          # Sized for up to ~16 GB of bf16 weights (Gemma-4-E4B).
+          memory: 24Gi
+          nvidia.com/gpu: "1"
+  restartPolicy: Never

--- a/experiments/model-manifest/k8s/executor-pod-g4.yaml
+++ b/experiments/model-manifest/k8s/executor-pod-g4.yaml
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# G4 executor: RTX PRO 6000 (Blackwell) pool, autoscales from zero.
+# The pool uses MPS sharing (48 clients/GPU), so nvidia.com/gpu: 1
+# requests one MPS slice of the physical GPU.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: manifest-executor-g4
+  labels:
+    app: manifest-executor
+    variant: g4
+spec:
+  nodeSelector:
+    cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+  containers:
+    - name: executor
+      image: IMAGE_PLACEHOLDER
+      command: ["sleep", "infinity"]
+      workingDir: /app
+      env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64
+      resources:
+        requests:
+          cpu: "4"
+          memory: 16Gi
+        limits:
+          memory: 16Gi
+          nvidia.com/gpu: "1"
+  restartPolicy: Never

--- a/experiments/model-manifest/src/export_graph.py
+++ b/experiments/model-manifest/src/export_graph.py
@@ -69,18 +69,31 @@ def main():
     sig = ep.graph_signature
     param_fqns = list(sig.inputs_to_parameters.values())
     buffer_fqns = list(sig.inputs_to_buffers.values())
-    strip = lambda fqn: fqn.removeprefix("model.")  # ForwardLogits wrapper prefix
-    # Weight tying: aliases resolved from config, not stored twice.
-    tied = {"lm_head.weight": "model.embed_tokens.weight"} if getattr(
-        config, "tie_word_embeddings", False) else {}
+    def lookup(fqn):
+        # Wrapper nesting adds leading prefixes; match by peeling them.
+        parts = fqn.split(".")
+        for i in range(len(parts)):
+            ref = manifest["tensors"].get(".".join(parts[i:]))
+            if ref is not None:
+                return ref
+        return None
+
+    # Weight tying: the alias resolves to whatever embed_tokens tensor the
+    # checkpoint stores (its nesting varies across architectures).
+    tied_ref = next(
+        (r for n, r in manifest["tensors"].items()
+         if n.endswith("embed_tokens.weight")), None)
+    # Buffers computed from config at init, never stored in checkpoints.
+    DERIVED_MARKERS = ("rotary_emb", "embed_scale", "softcap", "inv_timescales")
     bound, derived, unbound = {}, [], []
     for fqn in param_fqns + buffer_fqns:
-        name = strip(fqn)
-        ref = manifest["tensors"].get(name) or manifest["tensors"].get(tied.get(name, ""))
+        ref = lookup(fqn)
+        if ref is None and fqn.endswith("lm_head.weight"):
+            ref = tied_ref
         if ref is not None:
             bound[fqn] = ref
-        elif "rotary_emb" in fqn:
-            derived.append(fqn)  # computed from config (RoPE frequencies)
+        elif any(marker in fqn for marker in DERIVED_MARKERS):
+            derived.append(fqn)
         else:
             unbound.append(fqn)
 

--- a/experiments/model-manifest/src/serve_grpc.py
+++ b/experiments/model-manifest/src/serve_grpc.py
@@ -19,7 +19,11 @@ rehydrates them, and serves chat execution requests.
 """
 
 import argparse
+import gc
+import hashlib
 import sys
+import threading
+import time
 from concurrent import futures
 
 import grpc
@@ -31,32 +35,74 @@ from engine import Engine
 
 
 class ExecutorServicer(router_pb2_grpc.ModelExecutorServicer):
-    def __init__(self, device="cpu", compile_decode=False):
+    def __init__(self, device="cpu", compile_decode=False, keep_alive_s=60):
         self.device = device
         self.compile_decode = compile_decode
         self.engine = None
+        self.digest = None
+        self.last_used = time.time()
+        self.keep_alive_s = keep_alive_s
+        self.lock = threading.Lock()
+        reaper = threading.Thread(target=self._reap_idle, daemon=True)
+        reaper.start()
+
+    def _touch(self):
+        self.last_used = time.time()
+
+    def _reap_idle(self):
+        """Evict the engine after keep_alive_s without a request, so a
+        burst of asks amortizes one load but idle GPUs come back."""
+        while True:
+            time.sleep(5)
+            with self.lock:
+                idle = time.time() - self.last_used
+                if self.engine is not None and idle > self.keep_alive_s:
+                    print(f"[executor] Evicting model after {idle:.0f}s idle",
+                          flush=True)
+                    self.engine = None
+                    self.digest = None
+                    gc.collect()
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
 
     def LoadModel(self, request, context):
         try:
-            print("[executor] Loading model...", flush=True)
-            with open("manifest.json", "w") as f:
-                f.write(request.manifest_json)
-            with open("cached.binding.json", "w") as f:
-                f.write(request.binding_json)
-            with open("prefill.pt2", "wb") as f:
-                f.write(request.prefill_graph)
-            with open("decode.pt2", "wb") as f:
-                f.write(request.decode_graph)
+            digest = hashlib.sha256(
+                request.manifest_json.encode()
+                + request.binding_json.encode()
+                + request.prefill_graph
+                + request.decode_graph
+            ).hexdigest()
+            with self.lock:
+                self._touch()
+                if self.engine is not None and digest == self.digest:
+                    print(f"[executor] Model {digest[:12]} already loaded "
+                          "(content match); reusing", flush=True)
+                    return router_pb2.LoadModelResponse(success=True)
 
-            print("[executor] Initializing engine...", flush=True)
-            self.engine = Engine(
-                "manifest.json",
-                binding_path="cached.binding.json",
-                device=self.device,
-                compile_decode=self.compile_decode
-            )
-            print("[executor] Engine successfully initialized!", flush=True)
-            return router_pb2.LoadModelResponse(success=True)
+                print("[executor] Loading model...", flush=True)
+                with open("manifest.json", "w") as f:
+                    f.write(request.manifest_json)
+                with open("cached.binding.json", "w") as f:
+                    f.write(request.binding_json)
+                with open("prefill.pt2", "wb") as f:
+                    f.write(request.prefill_graph)
+                with open("decode.pt2", "wb") as f:
+                    f.write(request.decode_graph)
+
+                print("[executor] Initializing engine...", flush=True)
+                self.engine = Engine(
+                    "manifest.json",
+                    binding_path="cached.binding.json",
+                    device=self.device,
+                    compile_decode=self.compile_decode
+                )
+                self.digest = digest
+                # Touch again now: loading may exceed keep_alive_s, and
+                # the idle clock must start after the work, not before.
+                self._touch()
+                print("[executor] Engine successfully initialized!", flush=True)
+                return router_pb2.LoadModelResponse(success=True)
         except Exception as e:
             print(f"[executor] Error loading model: {e}", file=sys.stderr, flush=True)
             context.set_code(grpc.StatusCode.INTERNAL)
@@ -69,6 +115,7 @@ class ExecutorServicer(router_pb2_grpc.ModelExecutorServicer):
             context.set_details("Model has not been loaded yet. Call LoadModel first.")
             return router_pb2.NewSessionResponse()
         try:
+            self._touch()
             session_id = self.engine.new_session()
             print(f"[executor] Created new session: {session_id}", flush=True)
             return router_pb2.NewSessionResponse(session_id=session_id)
@@ -84,6 +131,7 @@ class ExecutorServicer(router_pb2_grpc.ModelExecutorServicer):
             context.set_details("Model has not been loaded yet. Call LoadModel first.")
             return router_pb2.ChatResponse()
         try:
+            self._touch()
             print(f"[executor] Chat for session: {request.session_id}", flush=True)
             reply = self.engine.chat(
                 request.session_id,
@@ -110,6 +158,8 @@ def main():
     parser.add_argument("--port", type=int, default=50051)
     parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
     parser.add_argument("--compile", action="store_true", default=torch.cuda.is_available())
+    parser.add_argument("--keep-alive", type=int, default=60,
+                        help="seconds to keep an idle model loaded")
     args = parser.parse_args()
 
     print(f"[executor] Starting gRPC server on port {args.port} (device: {args.device}, compile: {args.compile})", flush=True)
@@ -121,7 +171,8 @@ def main():
     ]
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10), options=options)
     router_pb2_grpc.add_ModelExecutorServicer_to_server(
-        ExecutorServicer(device=args.device, compile_decode=args.compile),
+        ExecutorServicer(device=args.device, compile_decode=args.compile,
+                         keep_alive_s=args.keep_alive),
         server
     )
     server.add_insecure_port(f"[::]:{args.port}")


### PR DESCRIPTION
## What

Five small commits that turn the model-manifest executor into a usable service and prove the thin-client thesis end to end:

1. **Go `ask` client** (`cmd/ask`) — inference with **zero PyTorch/Python on the client**: reads the interchange artifact (manifest + binding + weightless `.pt2` graphs), auto-`kubectl port-forward`s to the executor pod, ships the artifact inside `LoadModel` (retiring `kubectl cp`), opens a session, chats. Includes `k8s/executor-grpc-gpu.yaml` (long-lived `serve_grpc.py` on an L4) and image deps (grpcio, transformers 5.14.1).
2. **Executor keep-alive** — `LoadModel` is idempotent via the artifact's content digest; matching requests reuse the loaded engine, a reaper evicts after `--keep-alive` seconds idle (default 60) and frees the GPU. Includes a fix for the obvious trap: the idle clock starts when loading *finishes* (v1 evicted any model whose load exceeded the TTL).
3. **Gemma 4 binding support** — peel-prefix manifest lookup for multimodal nesting, tied-weight resolution by suffix, and `embed_scale`/`softcap`/`inv_timescales` as derived markers. `google/gemma-4-E4B-it` (2,098 tensors, 16 GB, ungated) now exports weightlessly with **zero unbound tensors**; SmolLM2 regression unchanged.
4. **G4 pod target + `GCP_PROJECT_ID`** — `--target g4` for the RTX PRO 6000 pool; `run-in-kube` honors `GCP_PROJECT_ID` over the gcloud default.
5. **Go toolchain 1.26.6** — fixes pre-existing govulncheck failures on main (stdlib GO-2026-6218, GO-2026-6090); `ap lint` is green again.

## Measured (L4, GKE)

```
$ ./ask
model loaded in 0.8s        # digest match within keep-alive (cold: ~100s, CAS-warm: ~6s)
>>> Is the sky blue?
The sky is indeed blue. ... known as Rayleigh scattering. ...
>>> Summarize your answer in one short sentence.
(34 tokens, 9.2 ms/token on the executor, 0.5s round trip)   # same session, KV cache live
```

## Notes for review

- Commits are independent and reviewable one at a time.
- Gemma 4 *execution* is not in this PR: the executor still needs its derived-tensor formulas (p-RoPE) and the hybrid sliding-window cache export — tracked as the next leg.